### PR TITLE
Resolves #590, added a coumple of fixes to the code.

### DIFF
--- a/ed_cluster/ed_cluster.module
+++ b/ed_cluster/ed_cluster.module
@@ -1819,7 +1819,7 @@ function ed_task_manager($test, $node) {
             $cell['title'] = t('Unchecked');
 	          //Check if it is late submission - if submitted on the due date or later
             if ((int)$answer['changed'] > (int)$task['due_date']) $cell['data'] = '!&nbsp;';
-            
+
             break;
 
           case 'accepted':
@@ -2577,10 +2577,12 @@ function ed_cluster_form_alter(&$form, &$form_state, $form_id) {
     drupal_add_js(drupal_get_path('module', 'edidaktikum') . '/node_list_editor/node_list_editor.js');
     drupal_add_css(drupal_get_path('module', 'edidaktikum') . '/node_list_editor/node_list_editor.css');
 
+    // Code assumes that corresponding taxonomy vocabulary does exist
+    $competenceVocabulary = taxonomy_vocabulary_machine_name_load('ed_competence_voc');
     $nle_data = [
       ["title" => "", "description" => "Name", "type" => "name", "name" => "name", "default" => "Õpiväljund"],
       ["title" => "", "description" => "Description", "type" => "text_area", "name" => "description"],
-      ["title" => "Competence", "description" => "", "type" => "taxonomy_list", "taxonomy_tree" => ed_get_taxonomy_tree(7), "name" => "competences"],
+      ["title" => "Competence", "description" => "", "type" => "taxonomy_list", "taxonomy_tree" => ed_get_taxonomy_tree($competenceVocabulary->vid), "name" => "competences"],
       ["title" => "", "description" => "Assessment method", "type" => "text_area", "name" => "assessment_method"]
     ];
 

--- a/edidaktikum.module
+++ b/edidaktikum.module
@@ -1448,7 +1448,6 @@ function ed_get_answer($task_id, $uid, $b_content = false, $group_members = fals
 function ed_get_taxonomy_tree($vid) {
     $q = db_select("taxonomy_term_data", "td");
     $q->fields("td", ["tid", "name", "weight"]);
-    $q->condition("format", "plain_text");
     $q->condition("vid", $vid);
     $q->join("taxonomy_term_hierarchy", "h", "h.tid = td.tid");
     $q->fields("h", ["parent"]);
@@ -1475,7 +1474,6 @@ function ed_get_taxonomy_tree($vid) {
 
     return $root;
 }
-
 
 function ed_get_group_bookmarks($gid) {
 	//  get group bookmarks


### PR DESCRIPTION
The issue was with the "plain_text" value condition for "format" field.
The live instance had "formatted_text" instead. The value is only
important for the case of "description" field and does not affect the
current functionality in any way. Removed that condition. Also made a
changed to the code that builds the form, made sure that the vocabulary
is not loaded by the unique identifier. The logic is to load the
vocabulary by machine name first and then use the unique identifier from
the result. The code does assume that vocabulary with certain machine
name does exist, but that is a bit better than hard-coded unique
identifier.