### PR TITLE
Resolves #350, implemented hook_node_info.

### DIFF
--- a/ed_file/ed_file.module
+++ b/ed_file/ed_file.module
@@ -6,6 +6,27 @@
  */
 
 /**
+ * Implements hook_node_info().
+ */
+function ed_file_node_info() {
+  $items['ed_file'] = [
+    'name' => t('File'),
+    'base' => 'node_content',
+    'description' => '',
+    'has_title' => TRUE,
+    'title_label' => t('Title'),
+  ];
+  $items['ed_file_folder'] = [
+    'name' => t('File folder'),
+    'base' => 'node_content',
+    'description' => '',
+    'has_title' => TRUE,
+    'title_label' => t('Title'),
+  ];
+  return $items;
+}
+
+/**
  * Implements hook_menu().
  */
 function ed_file_menu() {


### PR DESCRIPTION
It seems that implementing that hook allows to set title label with
code. Requires flushing the caches.