### PR TITLE
Resolves #687, extended January case fix logic.

### DIFF
--- a/ed_dashboard/ed_dashboard.module
+++ b/ed_dashboard/ed_dashboard.module
@@ -483,9 +483,8 @@ function _get_all_answers_to_task($task){
  * @return mixed
  */
 function _ed_get_group_tasks_for_month_year($gid, $month, $year){
-
-  //January case - should be next year
-  if($month == 1){
+  // January case should be next year, unless it is January right now
+  if($month == 1 && date('n') != 1){
     $year = $year + 1;
   }
 	$year_month = $year.'-'.$month;


### PR DESCRIPTION
Previous one just made sure that next year is used in case of January.
The new one is only applying it if currently is not January (as there is
no reason to increment year count in that case).