### PR TITLE
Fixed an issue with tasks and check_plain call.

### DIFF
--- a/ed_task/ed_task.module
+++ b/ed_task/ed_task.module
@@ -54,7 +54,6 @@ function ed_task_menu()
   //This view is for teachers
   $items['node/%node/task-results'] = array(
       'title' => 'Answers and feedback',
-      'title arguments' => ['Answers and feedback', 1, 'ed_task'],
       'page callback' => 'ed_task_results',
       'access callback' => 'ed_task_results_access',
       'page arguments' => array('node', 1),
@@ -65,7 +64,6 @@ function ed_task_menu()
   //This view is for students
   $items['node/%node/task-feedback'] = array(
       'title' => 'Feedback',
-      'title arguments' => ['Feedback', 1, 'ed_task'],
       'page callback' => 'ed_task_feedback',
       'access callback' => 'ed_task_feedback_access',
       'page arguments' => array('node', 1),


### PR DESCRIPTION
Removed the "title arguments" from defined task-results and task-feedback menus. Having no custom callback just sends those arguments straight to the translate function, which seems to be making sure that items are safe to use and thus passed an unneeded task object to the check_plain function. This remained hidden as it was not causing any issues and only raised a warning. An implicit string cast was added to Drupal Core version 7.89, which broke the task views and raised an error. That error unfortunately had a backtrace that did not directly point to the coause of the issue in the code, which made it hard to find the the circumstances.